### PR TITLE
Use waitress in production

### DIFF
--- a/lyli.py
+++ b/lyli.py
@@ -1,6 +1,7 @@
 #!flask/bin/python
 import logging
 
+from waitress import serve
 import werkzeug.serving
 
 from app import app
@@ -16,4 +17,6 @@ logging.basicConfig(filename='access.log', level=logging.DEBUG, format='%(messag
 if config.debug:
     app.run(port=3003, debug=True, use_reloader=True)
 else:
-    app.run(host="web", port=3004, debug=False, use_reloader=False)
+    logger = logging.getLogger('waitress')
+    logger.setLevel(logging.DEBUG)
+    serve(app, host='0.0.0.0', port=3004)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
+waitress
 redis
 WTForms==2.1


### PR DESCRIPTION
Flask complains about not recommending the use of development server in production. [This](https://stackoverflow.com/questions/51025893/flask-at-first-run-do-not-use-the-development-server-in-a-production-environmen) Stack Overflow discussion recommended waitress, which I implemented here. 